### PR TITLE
Fix graphql query interception

### DIFF
--- a/instagram-ssl-pinning-bypass.js
+++ b/instagram-ssl-pinning-bypass.js
@@ -7,6 +7,7 @@ function disableTigon() {
             IGTigonConfig.$init.implementation = function() {
                 this.$init();
                 this.isTigonEnabled.value = false;
+                this.isMnsEnabled.value = false;
                 logger("[*][+] Disable tigon")
             };
         });


### PR DESCRIPTION
Restores requests to https://i.instagram.com/graphql/query (Profile Settings, Followers, Following etc)